### PR TITLE
Fix Flash-of-Unstyled-Content (FOUC)

### DIFF
--- a/Themes.astro.template
+++ b/Themes.astro.template
@@ -4,6 +4,6 @@
 const { defaultTheme = 'light' } = Astro.props as Props
 ---
 
-<script type="module" define:vars={{ defaultTheme }}>
+<script define:vars={{ defaultTheme }}>
   {snippet}
 </script>

--- a/example/public/slow.js
+++ b/example/public/slow.js
@@ -1,0 +1,1 @@
+console.log('hi')

--- a/example/src/pages/slow.astro
+++ b/example/src/pages/slow.astro
@@ -1,0 +1,38 @@
+---
+import Themes from 'astro-themes'
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <title>Astro Themes Example</title>
+    <Themes />
+    <style>
+      html {
+        --background-color: white;
+        --text-color: black;
+
+        color: var(--text-color);
+        background-color: var(--background-color);
+      }
+
+      [data-theme='dark'] {
+        --background-color: black;
+        --text-color: white;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Astro Themes Example</h1>
+
+    <p>
+      I am text that appears in the body. Once I'm here and visible, the page
+      has been rendered.
+    </p>
+
+    <script is:inline type="text/javascript" src="/slow.js"></script>
+  </body>
+</html>

--- a/tests/fouc.test.ts
+++ b/tests/fouc.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Flash of Unstyled Content (FOUC)', () => {
+  test('should be dark theme IMMEDIATELY as text is rendered', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ colorScheme: 'dark' })
+
+    // throttle getting slow.js so that it doesn't immediately load
+    await page.route('/slow.js', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 5_000))
+      await route.continue()
+    })
+
+    // also don't wait for the page to load!
+    await page.goto('/slow', {
+      // "commit" = consider operation to be finished when network response is
+      // received and the document started loading.
+      waitUntil: 'commit',
+    })
+
+    // wait for the text to be in the body
+    await expect(
+      page.getByText('I am text that appears in the body.')
+    ).toBeVisible()
+
+    // now we should be able to immediately get the html element ...
+    const html = page.locator('html')
+
+    // ... and use a NON-retrying assertion to immediately assert. Once we
+    // have the html element we do NOT want to wait for data-theme to be
+    // available. It should be on the html element by the time we get here
+    // because the body text is already there!
+    expect(await html.getAttribute('data-theme')).toBe('dark')
+  })
+})


### PR DESCRIPTION
I noticed that my page had FOUC on page load. You can see it here: the OS is set to dark mode but the body is already rendering in light mode as the Themes.astro script starts executing (I have a breakpoint on the first line of the Themes script):

<img width="1589" alt="SCR-20250422-cweh" src="https://github.com/user-attachments/assets/d086896b-e6e6-4c3a-830c-6cfe5bb7ca4a" />

I looked into this and it appears that the culprit is that the Themes.astro script is defined as a module. Modules have deferred execution and can easily end up executing AFTER render, which is undesirable. We want the data-theme to be set before render in all cases.

[There is a `blocking` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/blocking) that can be set on `<script type="module" blocking="render">...</script>` that would give us the best possible behavior, but [it is unfortunately not available on Firefox](https://caniuse.com/mdn-api_htmlscriptelement_blocking).

So the only option is to remove type=module, and make the script fully blocking, which fixes my issue and makes it so that the page doesn't render before the script executes:

<img width="1610" alt="SCR-20250422-cwqy" src="https://github.com/user-attachments/assets/3e3b37fb-1bfe-49fc-898c-0290067a7204" />

I was able to, with some crazy specific assertions, get a playwright test that fails on the type=module version by detecting the FOUC. You can see in the playwright UI that the body renders in white at first:
<img width="1103" alt="image" src="https://github.com/user-attachments/assets/2f42622e-48b2-4bd3-8e51-5b9d0f00c1c2" />

And after my fix, it always renders in the right theme after the Themes script runs:
<img width="854" alt="image" src="https://github.com/user-attachments/assets/0c83785c-f60e-4dd1-a147-93eddaad83ad" />

(My apologies for not opening an issue first. I just wanted to get this fixed.)